### PR TITLE
WIP: Indent soft wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     }
   ],
   "dependencies": {
-    "event-kit": "^1.0.3"
+    "event-kit": "^1.0.3",
+    "underscore-plus": "^1.6.6"
   },
   "devDependencies": {
     "coffee-script": "^1.7.0",

--- a/spec/soft-wraps-layer-spec.coffee
+++ b/spec/soft-wraps-layer-spec.coffee
@@ -26,6 +26,7 @@ describe "soft wraps layer", ->
 
     expect(softWrapsLayer.clipPosition(Point(1, 6), 'backward')).toEqual Point(1, 5)
     expect(softWrapsLayer.clipPosition(Point(1, 6), 'forward')).toEqual Point(2, 2)
+    expect(softWrapsLayer.clipPosition(Point(2, 1), 'backward')).toEqual Point(1, 5)
 
   it "soft-wraps lines based on line length, ::baseCharacterWidth, and ::contentFrameWidth", ->
     buffer = new TextBuffer(text: 'abc def ghi jklmno\tpqr')

--- a/spec/soft-wraps-layer-spec.coffee
+++ b/spec/soft-wraps-layer-spec.coffee
@@ -2,6 +2,31 @@ TextBuffer = require '../src/text-buffer'
 Point = require '../src/point'
 
 describe "soft wraps layer", ->
+  it "carries indentation on soft-wrapped lines", ->
+    buffer = new TextBuffer(text: '\tabc def ghi jklmnopqr')
+    linesLayer = buffer.getLinesLayer()
+    softWrapsLayer = buffer.buildSoftWrapsLayer(baseCharacterWidth: 10, clientWidth: 100, tabLength: 2)
+    expect(softWrapsLayer.slice(Point(0, 0), Point(1, 0))).toBe "  abc def "
+    expect(softWrapsLayer.slice(Point(1, 0), Point(2, 0))).toBe "  ghi "
+    expect(softWrapsLayer.slice(Point(2, 0), Point(3, 0))).toBe "  jklmnopqr"
+
+    mappings = [
+      [[0, 0], [0, 0]]
+      [[0, 7], [0, 8]]
+      [[0, 9], [1, 2]]
+      [[0, 12], [1, 5]]
+      [[0, 13], [2, 2]]
+      [[0, 14], [2, 3]]
+    ]
+
+    for [linesPoint, softWrapsPoint, options] in mappings
+      unless options?
+        expect(softWrapsLayer.fromPositionInLayer(Point(linesPoint...), linesLayer)).toEqual Point(softWrapsPoint...)
+      expect(softWrapsLayer.toPositionInLayer(Point(softWrapsPoint...), linesLayer, options)).toEqual Point(linesPoint...)
+
+    expect(softWrapsLayer.clipPosition(Point(1, 6), 'backward')).toEqual Point(1, 5)
+    expect(softWrapsLayer.clipPosition(Point(1, 6), 'forward')).toEqual Point(2, 2)
+
   it "soft-wraps lines based on line length, ::baseCharacterWidth, and ::contentFrameWidth", ->
     buffer = new TextBuffer(text: 'abc def ghi jklmno\tpqr')
     linesLayer = buffer.getLinesLayer()

--- a/src/characters-transform.coffee
+++ b/src/characters-transform.coffee
@@ -6,6 +6,9 @@ module.exports =
 class CharactersTransform
   initialize: (@source) ->
 
+  getNextRegions: ({sourceStartPosition}) ->
+    [@getNextRegion({sourceStartPosition})]
+
   getNextRegion: ({sourceStartPosition}) ->
     sourcePosition = sourceStartPosition
     maxSourcePosition = @source.getEndPosition()

--- a/src/layer.coffee
+++ b/src/layer.coffee
@@ -12,11 +12,11 @@ class Layer
     regions = []
 
     while sourceStartPosition.isLessThan(sourceEndPosition)
-      region = @transform.getNextRegion({sourceStartPosition, targetStartPosition})
-      break unless region.sourceTraversal.isGreaterThan(Point.ZERO) or region.targetTraversal.isGreaterThan(Point.ZERO)
-      sourceStartPosition = sourceStartPosition.traverse(region.sourceTraversal)
-      targetStartPosition = targetStartPosition.traverse(region.targetTraversal)
-      regions.push(region)
+      for region in @transform.getNextRegions({sourceStartPosition, targetStartPosition})
+        break unless region.sourceTraversal.isGreaterThan(Point.ZERO) or region.targetTraversal.isGreaterThan(Point.ZERO)
+        sourceStartPosition = sourceStartPosition.traverse(region.sourceTraversal)
+        targetStartPosition = targetStartPosition.traverse(region.targetTraversal)
+        regions.push(region)
 
     regions
 

--- a/src/lines-transform.coffee
+++ b/src/lines-transform.coffee
@@ -5,6 +5,9 @@ module.exports =
 class LinesTransform
   initialize: (@source) ->
 
+  getNextRegions: ({sourceStartPosition}) ->
+    [@getNextRegion({sourceStartPosition})]
+
   getNextRegion: ({sourceStartPosition}) ->
     if newlinePosition = @source.positionOf('\n', sourceStartPosition)
       sourceEndPosition = newlinePosition.traverse(Point(0, 1))

--- a/src/soft-wraps-transform.coffee
+++ b/src/soft-wraps-transform.coffee
@@ -7,6 +7,9 @@ class SoftWrapsTransform
 
   initialize: (@source) ->
 
+  getNextRegions: ({sourceStartPosition}) ->
+    [@getNextRegion({sourceStartPosition})]
+
   getNextRegion: ({sourceStartPosition}) ->
     sourceLineEnd = @source.clipPosition(sourceStartPosition.traverse(Point(0, Infinity)))
     width = 0

--- a/src/soft-wraps-transform.coffee
+++ b/src/soft-wraps-transform.coffee
@@ -1,5 +1,6 @@
 Point = require './point'
 Region = require './region'
+_ = require 'underscore-plus'
 
 module.exports =
 class SoftWrapsTransform
@@ -8,12 +9,11 @@ class SoftWrapsTransform
   initialize: (@source) ->
 
   getNextRegions: ({sourceStartPosition}) ->
-    [@getNextRegion({sourceStartPosition})]
-
-  getNextRegion: ({sourceStartPosition}) ->
+    regions = []
     sourceLineEnd = @source.clipPosition(sourceStartPosition.traverse(Point(0, Infinity)))
     width = 0
     sourcePosition = sourceStartPosition
+    start = sourceStartPosition
 
     while sourcePosition.isLessThan(sourceLineEnd)
       nextSourcePosition = @source.clipPosition(sourcePosition.traverse(Point(0, 1)), 'forward')
@@ -22,15 +22,33 @@ class SoftWrapsTransform
       if /\s/.test(@source.characterAt(sourcePosition))
         sourceEndPosition = nextSourcePosition
       else if width > @clientWidth
-        targetTraversal = Point(1, 0)
-        break
+        width = 0
+        sourceTraversal = sourceEndPosition.traversalFrom(start)
+        regions.push new Region(sourceTraversal, Point(1, 0))
+        start = sourceEndPosition
+        if @hasTabAt(sourceStartPosition)
+          # TODO: replace "2" with the real indentation
+          regions.push new Region(Point(0, 0), Point(0, 2), 'exclusive')
+          width += @baseCharacterWidth * 2
 
       sourcePosition = nextSourcePosition
 
     sourceEndPosition ?= sourcePosition
-    sourceTraversal = sourceEndPosition.traversalFrom(sourceStartPosition)
-    targetTraversal ?= sourceTraversal
-    new Region(sourceTraversal, targetTraversal)
+    sourceTraversal = sourceEndPosition.traversalFrom(start)
+    regions.push(new Region(sourceTraversal, sourceTraversal)) if regions.length == 0
+    regions
 
-  getContent: ({sourceStartPosition, sourceEndPosition}) ->
-    @source.slice(sourceStartPosition, sourceEndPosition)
+  hasTabAt: (sourceStartPosition) ->
+    tabPosition = @source.positionOf('\t', sourceStartPosition)
+    return unless tabPosition
+
+    tabPosition.isEqual(sourceStartPosition)
+
+  getContent: ({sourceStartPosition, sourceEndPosition, targetStartPosition, targetEndPosition}) ->
+    if sourceStartPosition.isEqual(sourceEndPosition)
+      _.multiplyString(
+        " ",
+        targetEndPosition.traversalFrom(targetStartPosition).columns
+      )
+    else
+      @source.slice(sourceStartPosition, sourceEndPosition)

--- a/src/soft-wraps-transform.coffee
+++ b/src/soft-wraps-transform.coffee
@@ -38,11 +38,11 @@ class SoftWrapsTransform
     regions.push(new Region(sourceTraversal, sourceTraversal)) if regions.length == 0
     regions
 
-  hasTabAt: (sourceStartPosition) ->
-    tabPosition = @source.positionOf('\t', sourceStartPosition)
+  hasTabAt: (position) ->
+    tabPosition = @source.positionOf('\t', position)
     return unless tabPosition
 
-    tabPosition.isEqual(sourceStartPosition)
+    tabPosition.isEqual(position)
 
   getContent: ({sourceStartPosition, sourceEndPosition, targetStartPosition, targetEndPosition}) ->
     if sourceStartPosition.isEqual(sourceEndPosition)

--- a/src/tabs-transform.coffee
+++ b/src/tabs-transform.coffee
@@ -7,6 +7,9 @@ class TabsTransform
 
   initialize: (@source) ->
 
+  getNextRegions: ({sourceStartPosition, targetStartPosition}) ->
+    [@getNextRegion({sourceStartPosition, targetStartPosition})]
+
   getNextRegion: ({sourceStartPosition, targetStartPosition}) ->
     if tabPosition = @source.positionOf('\t', sourceStartPosition)
       if tabPosition.isEqual(sourceStartPosition)


### PR DESCRIPTION
This doesn't fully work yet but it may be useful to show it nevertheless, because I think it demonstrates two things:
1. Implementing this on [atom/atom](https://github.com/atom/atom/pull/5567) required me to touch several places in the application. Sure, this project is definitely smaller and there are less constraints in place, but I think this a good indicator that we're on the right track, @nathansobo: a centralized place where we can handle buffer-related stuff seems like a nice thing to have.
2. Although it's great that each transformation handle its own thing, it seems to me like some concepts cross many `Transform` objects. For instance, as you can see in this PR, I needed to identify which was the current line's indentation: a rudimental implementation was to simply inspect the leading source positions for the presence of tabs; however, I feel like, at this level, we should not decrease the level of abstraction but rather, only where it makes sense,  collect information for each layer transformation and make it available to the next ones (I am thinking to something like Rack). 

There are still a couple of issues in this PR. The most important is that clipping backwards does not work when we are on a soft-wrapped line with indentation: I need to dig a bit deeper, but I feel like this should be quite easy to fix.

/cc: @maxbrunsfeld @nathansobo 
